### PR TITLE
fix: More reliable (and correct) download

### DIFF
--- a/lib/chromedriver/version.js
+++ b/lib/chromedriver/version.js
@@ -36,6 +36,8 @@ void function () {
         version = FALLBACK_CHROMEDRIVER_VERSION;
         console.log('[testium] Unable to determine latest version of selenium chromedriver; using ' + version);
         console.error(error.stack || error);
+      } else {
+        version = version.trim();
       }
       cache$ = getArchitecture();
       platform = cache$.platform;

--- a/lib/selenium/download.js
+++ b/lib/selenium/download.js
@@ -6,15 +6,16 @@ void function () {
   downloadFile = require('../download');
   validate = require('../checksum');
   module.exports = function (binPath, tempPath, url, version, callback) {
-    var binFilePath, file, tempFileName, tempFilePath;
+    var binFilePath, file, tempFileName, tempFilePath, validTempFilePath;
     file = 'selenium.jar';
     binFilePath = '' + binPath + '/' + file;
     if (fs.existsSync(binFilePath))
       return callback();
     tempFileName = 'selenium_' + version + '.jar';
     tempFilePath = '' + tempPath + '/' + tempFileName;
-    if (fs.existsSync(tempFilePath)) {
-      return copy(tempFilePath, binFilePath, callback);
+    validTempFilePath = '' + tempPath + '/' + tempFileName + '.valid';
+    if (fs.existsSync(validTempFilePath)) {
+      return copy(validTempFilePath, binFilePath, callback);
     } else {
       return downloadFile(url, tempPath, tempFileName, function (error, hash) {
         if (null != error)
@@ -22,7 +23,11 @@ void function () {
         return validate(tempFilePath, hash, function (error) {
           if (null != error)
             return callback(error);
-          return copy(tempFilePath, binFilePath, callback);
+          return copy(tempFilePath, validTempFilePath, function (error) {
+            if (null != error)
+              return callback(error);
+            return copy(tempFilePath, binFilePath, callback);
+          });
         });
       });
     }

--- a/src/chromedriver/version.coffee
+++ b/src/chromedriver/version.coffee
@@ -63,6 +63,8 @@ module.exports = (callback) ->
       version = FALLBACK_CHROMEDRIVER_VERSION
       console.log "[testium] Unable to determine latest version of selenium chromedriver; using #{version}"
       console.error (error.stack || error)
+    else
+      version = version.trim()
 
     {platform, bitness} = getArchitecture()
     downloadUrl = "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_#{platform}#{bitness}.zip"

--- a/src/selenium/download.coffee
+++ b/src/selenium/download.coffee
@@ -42,8 +42,10 @@ module.exports = (binPath, tempPath, url, version, callback) ->
 
   tempFileName = "selenium_#{version}.jar"
   tempFilePath = "#{tempPath}/#{tempFileName}"
-  if fs.existsSync tempFilePath
-    copy tempFilePath, binFilePath, callback
+  validTempFilePath = "#{tempPath}/#{tempFileName}.valid"
+
+  if fs.existsSync validTempFilePath
+    copy validTempFilePath, binFilePath, callback
   else
     downloadFile url, tempPath, tempFileName, (error, hash) ->
       return callback error if error?
@@ -51,5 +53,6 @@ module.exports = (binPath, tempPath, url, version, callback) ->
       validate tempFilePath, hash, (error) ->
         return callback error if error?
 
-        copy tempFilePath, binFilePath, callback
-
+        copy tempFilePath, validTempFilePath, (error) ->
+          return callback error if error?
+          copy tempFilePath, binFilePath, callback

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,4 +1,6 @@
 fs = require 'fs'
+{execFile} = require 'child_process'
+
 assert = require 'assert'
 rmrf = require 'rimraf'
 
@@ -30,7 +32,13 @@ seleniumDownload.update BIN_PATH, (error) ->
     assert fs.existsSync(BIN_PATH + '/chromedriver')
     assert fs.existsSync(BIN_PATH + '/selenium.jar')
 
-    clearFileSystem()
+    console.log 'make sure it did not download an invalid jar'
+    execFile 'java', [
+      # -h means "show usage/help". Selenium has no --version :(
+      '-jar', BIN_PATH + '/selenium.jar', '-h'
+    ], (error, stdout) ->
+      throw error if error?
+      clearFileSystem()
 
 process.on 'uncaughtException', (error) ->
   clearFileSystem()


### PR DESCRIPTION
* The chrome version info may contain a trailing new line.
  This broke our url generation.
* The broken chrome url lead to the process crashing which lead to
  a broken tmp file. And once that tmp file existed, it was blindly
  copied. We're now waiting for the download to complete and then
  copy the file to a new name once it was actually validated.
  There's still a small window where we may end up in a broken
  state but it's progress.