### PR TITLE
Fix failing OSX chromedriver download due to 2.23 dropped support for mac 32 bit

### DIFF
--- a/lib/chromedriver/version.js
+++ b/lib/chromedriver/version.js
@@ -30,7 +30,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 'use strict';
-var FALLBACK_CHROMEDRIVER_VERSION = '2.22';
+var FALLBACK_CHROMEDRIVER_VERSION = '2.23';
 
 var request = require('request');
 
@@ -44,7 +44,7 @@ function getArchitecture() {
   var bitness = process.arch.substr(1);
   if (platform === 'darwin') {
     platform = 'mac';
-    bitness = '32';
+    bitness = '64';
   }
   if (platform === 'win32') {
     platform = 'win';


### PR DESCRIPTION
Fixes #29 


## Problem/bug
For some reason, chromedriver 2.23 no longer supports Mac 32-bit, replacing it instead with a 64-bit version: 

![chromedriver version gif](https://camo.githubusercontent.com/0c64cc51172ee8c1bf6003250efa5a4ddb82b529/68747470733a2f2f64337676366c703535716a6171632e636c6f756466726f6e742e6e65742f6974656d732f3269334d3355315433483359336c3344315333592f53637265656e2532305265636f7264696e67253230323031362d30382d3137253230617425323030322e3032253230504d2e6769663f763d3736366139623333)

This caused `npm test` to fail on OS X, as `selenium-download` attempted to download the nonexistent [mac_32.zip](http://chromedriver.storage.googleapis.com/2.23/chromedriver_mac32.zip).  

![image](https://cloud.githubusercontent.com/assets/2163045/17758394/a0f074a0-648a-11e6-94e7-3603eaeb7046.png)

## Solution/Fix

This fix updates the fallback chromedriver version to 2.23 and defaults the OS X `bitness` to `'64'`. Tests now pass:

 
![image](https://cloud.githubusercontent.com/assets/2163045/17758421/f23a59f2-648a-11e6-929e-e87833cbfc38.png)



### Further improvements
This issue took quite a while for my team and I to diagnose, because the error handling for chromedriver installation will still create an empty, 0-byte `chromedriver` executable _even if the download fails_.  Worse, if you use `ensure()`, the `fs.existsSync()` call will detect that `chromedriver` exists and short-circuit, leaving you stuck with the empty executable!  Only a `forceUpdate` call will retry the download.

I started to work on a solution to this, but figured I'd bring it up here in the context of this quick-fix.  Basically I'd love it if a failed download did not result in that empty binary.  (It would also be great if a parameter allowed download of a specific version of chromedriver and selenium, but that's a feature request 😉)
