### PR TITLE
Fail cleanly when the chromedriver download 404s

### DIFF
--- a/lib/chromedriver/download.js
+++ b/lib/chromedriver/download.js
@@ -33,6 +33,7 @@
 var fs = require('fs');
 
 var async = require('async');
+var debug = require('debug')('selenium-download:chromedriver:download');
 var fsExtra = require('fs.extra');
 var AdmZip = require('adm-zip');
 var _ = require('lodash');
@@ -62,9 +63,37 @@ function unzip(tempPath, filePath, callback) {
   return move(filePath, tempFilePath, onMoved);
 }
 
+function isValidExecutable(filename) {
+  var stat;
+  try {
+    stat = fs.statSync(filename);
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    return false;
+  }
+  debug('size(%j) = %d', filename, stat.size);
+  // Quick sanity check - it should be bigger than an elf binary header
+  return stat.size > 64;
+}
+
+function copyReplace(source, dest, callback) {
+  function onDestUnlinked(err) {
+    if (err && err.code !== 'ENOENT') {
+      callback(err);
+      return;
+    }
+    if (!err) {
+      debug('removed old file at', dest);
+    }
+    copy(source, dest, callback);
+  }
+  fs.unlink(dest, onDestUnlinked);
+}
+
 function downloadChromeDriver(binPath, tempPath, version, url, callback) {
   var chromedriverPath = binPath + '/chromedriver';
-  if (fs.existsSync(chromedriverPath)) {
+  if (isValidExecutable(chromedriverPath)) {
+    debug('already downloaded', chromedriverPath);
     return callback();
   }
   var tempFileName = 'chromedriver_' + version;
@@ -77,9 +106,14 @@ function downloadChromeDriver(binPath, tempPath, version, url, callback) {
     return fs.chmod(chromedriverPath, '755', callback);
   }
 
-  if (fs.existsSync(tempFilePath)) {
-    return copy(tempFilePath, chromedriverPath, makeExecutable);
+  if (isValidExecutable(tempFilePath)) {
+    debug('using previous download', tempFilePath);
+    return copyReplace(tempFilePath, chromedriverPath, makeExecutable);
   }
+
+  debug('download url', url);
+  debug('tmp file', tempFilePath);
+  debug('target file', chromedriverPath);
 
   var unzippedFilePath = tempPath + '/chromedriver' + extension;
   return async.waterfall([
@@ -87,7 +121,7 @@ function downloadChromeDriver(binPath, tempPath, version, url, callback) {
     _.partial(validate, tempFilePath),
     _.partial(unzip, tempPath, tempFilePath),
     _.partial(move, unzippedFilePath, tempFilePath),
-    _.partial(copy, tempFilePath, chromedriverPath)
+    _.partial(copyReplace, tempFilePath, chromedriverPath)
   ], makeExecutable);
 }
 module.exports = downloadChromeDriver;

--- a/lib/download.js
+++ b/lib/download.js
@@ -33,6 +33,7 @@
 var fs = require('fs');
 var path = require('path');
 
+var _ = require('lodash');
 var request = require('request');
 
 function parseHashes(rawHash) {
@@ -48,20 +49,21 @@ function parseHashes(rawHash) {
 }
 
 function downloadWithMD5(url, destinationDir, fileName, callback) {
-  var hash = null;
-  var stream = request(url, { gzip: true });
-  var fileStream = fs.createWriteStream(path.join(destinationDir, fileName));
-  stream.pipe(fileStream);
-  stream.on('response', function onResponse(response) {
-    var rawHash;
-    rawHash = response.headers['x-goog-hash'];
-    hash = parseHashes(rawHash).md5;
-  });
-  stream.on('error', callback);
-  fileStream.on('error', callback);
+  function onResponse(err, response, body) {
+    if (err) return callback(err);
+    if (response.statusCode !== 200) {
+      return callback(new Error(response.statusCode + ' - failed to download ' + url));
+    }
 
-  fileStream.on('close', function returnHash() {
-    callback(null, hash);
-  });
+    var rawHash = response.headers['x-goog-hash'];
+    if (!rawHash) {
+      return callback(new Error('Response did not contain a checksum: ' + url));
+    }
+
+    var absoluteFile = path.join(destinationDir, fileName);
+    return fs.writeFile(absoluteFile, body, _.partial(callback, _, parseHashes(rawHash).md5));
+  }
+
+  request(url, { gzip: true, encoding: null }, onResponse);
 }
 module.exports = downloadWithMD5;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "adm-zip": "~0.4.4",
     "async": "~0.2.10",
+    "debug": "^2.2.0",
     "fs.extra": "^1.2.1",
     "lodash": "^4.6.1",
     "mkdirp": "~0.3.5",

--- a/test/chromedriver/download.test.js
+++ b/test/chromedriver/download.test.js
@@ -1,0 +1,47 @@
+'use strict';
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+
+var assert = require('assertive');
+
+var downloadChromeDriver = require('../../lib/chromedriver/download');
+
+// Downloaded, started to make sure it works, copied the file size.
+var CHROME_DRIVER_SIZE = 10907892;
+
+function tryRemove(filename) {
+  try {
+    fs.unlinkSync(filename);
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+describe('downloadChromeDriver', function () {
+  it('fails cleanly when the file is empty', function (done) {
+    var tmpDir = os.tmpdir();
+    var tmpFilePath = path.join(tmpDir, 'chromedriver_0.23');
+    var driverPath = path.join(tmpDir, 'chromedriver');
+
+    var badUrl = 'https://chromedriver.storage.googleapis.com/2.23/chromedriver_mac32.zip';
+    var goodUrl = 'https://chromedriver.storage.googleapis.com/2.23/chromedriver_mac64.zip';
+
+    tryRemove(tmpFilePath);
+    tryRemove(driverPath);
+
+    downloadChromeDriver(tmpDir, tmpDir, '0.23', badUrl, function (expectedError) {
+      assert.truthy(expectedError);
+      assert.include('404', expectedError.message);
+
+      downloadChromeDriver(tmpDir, tmpDir, '0.23', goodUrl, function (unexpectedError) {
+        if (unexpectedError) {
+          done(unexpectedError);
+          return;
+        }
+        assert.equal(CHROME_DRIVER_SIZE, fs.statSync(tmpFilePath).size);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Just contains a basic minimal check. Future improvement would be to keep the checksum around in a file and only use the temp file when the checksum can be verified. For now this should cover the issue(s) at hand.

Follow-up to https://github.com/groupon/selenium-download/pull/30.