### PR TITLE
chore: Do not show error stack trace if latest version was not found

### DIFF
--- a/lib/selenium/version.js
+++ b/lib/selenium/version.js
@@ -73,9 +73,12 @@ function parseSelenium(result) {
     const standalone = _.find(contents, function matchContent(content) {
       return content.Key[0].match(/selenium-server-standalone-/);
     });
+    const version = standalone
+      ? standalone.Key[0].match(/(\d+\.\d+\.\d+)/)[0]
+      : null;
     return {
       error: null,
-      version: standalone.Key[0].match(/(\d+\.\d+\.\d+)/)[0],
+      version,
     };
   } catch (parseError) {
     return { error: parseError, version: null };
@@ -136,14 +139,16 @@ function getLatestVersion(callback) {
 
 function getLatestDownloadInfo(callback) {
   return getLatestVersion(function onVersion(error, version) {
-    if (error != null) {
+    if (version === null) {
       version = FALLBACK_SELENIUM_VERSION;
       /* eslint no-console: 0 */
       console.log(
         '[testium] Unable to determine latest version of selenium standalone server; using %s',
         version
       );
-      console.error(error.stack || error);
+      if (error !== null) {
+        console.error(error.stack || error);
+      }
     }
     const minorVersion = getMinor(version);
     const downloadUrl = buildDownloadUrl(version, minorVersion);


### PR DESCRIPTION
This PR is just a minor thing...

When `result` processed by `parseSelenium` contains `ListBucketResult.Contents` that does not include `Key[0]` that matches `/selenium-server-standalone-/`, then 
```
version: standalone.Key[0].match(/(\d+\.\d+\.\d+)/)[0],
```
will throw an exception.

Selenium will be downloaded just fine, but this message 
```
[testium] Unable to determine latest version of selenium standalone server; using 2.53.0
TypeError: Cannot read property 'Key' of undefined
    at parseSelenium (path/to/project/node_modules/selenium-download/lib/selenium/version.js:67:27)
    at onFullVersionData (path/to/project/node_modules/selenium-download/lib/selenium/version.js:105:20)
    at onParsedXml (path/to/project/node_modules/selenium-download/lib/selenium/version.js:79:12)
    at Parser.<anonymous> (path/to/project/node_modules/xml2js/lib/parser.js:303:18)
    at Parser.emit (events.js:127:13)
    at SAXParser.onclosetag (path/to/project/node_modules/xml2js/lib/parser.js:261:26)
    at emit (path/to/project/node_modules/sax/lib/sax.js:624:35)
    at emitNode (path/to/project/node_modules/sax/lib/sax.js:629:5)
    at closeTag (path/to/project/node_modules/sax/lib/sax.js:889:7)
    at SAXParser.write (path/to/project/node_modules/sax/lib/sax.js:1436:13)
```
"scared" some of my colleagues, especially, when we updated to the latest version.

This PR hides this error trace if version is not found.