### PR TITLE
add extension for windows

### DIFF
--- a/lib/chromedriver/download.js
+++ b/lib/chromedriver/download.js
@@ -92,7 +92,7 @@ function copyReplace(source, dest, callback) {
 }
 
 function downloadChromeDriver(binPath, tempPath, version, url, callback) {
-  const chromedriverPath = `${binPath}/chromedriver`;
+  const chromedriverPath = `${binPath}/chromedriver${extension}`;
   if (isValidExecutable(chromedriverPath)) {
     debug('already downloaded', chromedriverPath);
     return callback();


### PR DESCRIPTION
As requested in issue https://github.com/groupon/selenium-download/issues/41 .
I just ran into the same problem and thought I would push the change.
Tested it on windows 10 and macOS.